### PR TITLE
Support single file hclfmt

### DIFF
--- a/autoload/fmt.vim
+++ b/autoload/fmt.vim
@@ -6,7 +6,7 @@ function! fmt#Format()
     return
   endif
   let l:curw = winsaveview()
-  let output = system('terragrunt hclfmt')
+  let output = system('terragrunt hclfmt --terragrunt-hclfmt-file ' . expand('%:p'))
   if v:shell_error == 0
     try | silent undojoin | catch | endtry
     silent edit!


### PR DESCRIPTION
Added --terragrunt-hclfmt-file option, which enables less invasive hclfmt and also enables formatting of the file outside of current working directory, like `../terragrunt.hcl`.