### PR TITLE
Support single file hclfmt with file/folder spaces in name

### DIFF
--- a/autoload/fmt.vim
+++ b/autoload/fmt.vim
@@ -6,7 +6,7 @@ function! fmt#Format()
     return
   endif
   let l:curw = winsaveview()
-  let output = system('terragrunt hclfmt --terragrunt-hclfmt-file ' . expand('%:p'))
+  let output = system('terragrunt hclfmt --terragrunt-hclfmt-file "' . expand('%:p') . '"')
   if v:shell_error == 0
     try | silent undojoin | catch | endtry
     silent edit!


### PR DESCRIPTION
Related to #4. Adds support for folders/files with spaces or other special characters in name.