### PR TITLE
add updated hcl fmt with fallback to hclfmt

### DIFF
--- a/autoload/fmt.vim
+++ b/autoload/fmt.vim
@@ -1,4 +1,4 @@
-" fmt.vim: Vim command to format terragrunt HCL files with terragrunt hclfmt.
+" fmt.vim: Vim command to format terragrunt HCL files with terragrunt hcl fmt.
 
 function! fmt#Format()
   write
@@ -6,7 +6,12 @@ function! fmt#Format()
     return
   endif
   let l:curw = winsaveview()
-  let output = system('terragrunt hclfmt --terragrunt-hclfmt-file "' . expand('%:p') . '"')
+  " Try new command first (Terragrunt >= v0.x with CLI redesign)
+  let output = system('terragrunt hcl fmt --file "' . expand('%:p') . '"')
+  " Fall back to old command if new command fails
+  if v:shell_error != 0
+    let output = system('terragrunt hclfmt --terragrunt-hclfmt-file "' . expand('%:p') . '"')
+  endif
   if v:shell_error == 0
     try | silent undojoin | catch | endtry
     silent edit!


### PR DESCRIPTION
## Update to support terragrunt hcl fmt command

Updates the plugin to use the current `terragrunt hcl fmt --file` command while maintaining backward compatibility with older versions using `terragrunt hclfmt --terragrunt-hclfmt-file`.

### Changes:
- Updated command from deprecated `terragrunt hclfmt` to `terragrunt hcl fmt`
- Added fallback to legacy command for backward compatibility with older Terragrunt versions
- Updated comments to reflect new command

### Testing:
Tested with Terragrunt v0.87.4 and formatting works correctly.

### Backward Compatibility:
If the new command fails, the plugin automatically falls back to the old command, ensuring it works with both old and new Terragrunt versions.